### PR TITLE
Bump Version to 8.14.1 for 1877.2

### DIFF
--- a/prepare_source
+++ b/prepare_source
@@ -1,5 +1,6 @@
 pkg=curl
 version_orig=8.14.1-2
+version_suffix=gl0
 git_src -b "debian/$version_orig" "https://salsa.debian.org/debian/curl.git"
 
 #removing rtmp


### PR DESCRIPTION
**What this PR does / why we need it**:
This bumps the version to `8.14.1` for Gardenlinux release `1877.2`

**Which issue(s) this PR fixes:**
Related to: https://github.com/gardenlinux/gardenlinux/issues/3197