### PR TITLE
Add backport qualifier to version suffix

### DIFF
--- a/prepare_source
+++ b/prepare_source
@@ -1,6 +1,6 @@
 pkg=curl
 version_orig=8.14.1-2
-version_suffix=gl0
+version_suffix=gl0+bp1877
 git_src -b "debian/$version_orig" "https://salsa.debian.org/debian/curl.git"
 
 #removing rtmp


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds the backport qualifier to the version suffix
