### PR TITLE
this removes dependency on libngtcp2 -- which we do not maintain

### DIFF
--- a/patches/0001_disable_http3.patch
+++ b/patches/0001_disable_http3.patch
@@ -1,0 +1,13 @@
+diff --git a/debian/rules b/debian/rules
+index 4b8991698..6f45f92fc 100755
+--- a/debian/rules
++++ b/debian/rules
+@@ -13,7 +13,7 @@ CONFIGURE_ARGS = -- --disable-dependency-tracking		\
+ 	--enable-symbol-hiding --enable-versioned-symbols	\
+ 	--enable-threaded-resolver --with-lber-lib=lber		\
+ 	--with-gssapi=/usr --with-nghttp2	\
+-	--with-ngtcp2 --with-nghttp3	\
++	--with-ngtcp2 --without-nghttp3 \
+ 	--includedir=/usr/include/$(DEB_HOST_MULTIARCH)		\
+ 	--with-zsh-functions-dir=/usr/share/zsh/vendor-completions \
+ 	--with-fish-functions-dir=/usr/share/fish/vendor_completions.d \

--- a/patches/series
+++ b/patches/series
@@ -1,0 +1,1 @@
+0001_disable_http3.patch

--- a/prepare_source
+++ b/prepare_source
@@ -1,7 +1,9 @@
 pkg=curl
 version_orig=8.19.0
-version="$version_orig-1"
-git_src -b "debian/$version" "https://salsa.debian.org/debian/curl.git"
+version="$version_orig-2"
+git_src -b "debian/$version_orig-1" "https://salsa.debian.org/debian/curl.git"
 
 #removing rtmp
 sed -i '/librtmp-dev/d;s/RTMP, //' "$dir/src/debian/control"
+
+apply_patches


### PR DESCRIPTION
**What this PR does / why we need it**: 2150.1.0 release breaks because of unresolvable dependency on libngtcp2

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardenlinux/gardenlinux/issues/4382

**Special notes for your reviewer**:

This patch was already successfully applied to 1877 patch release: https://github.com/gardenlinux/package-curl/blob/rel-1877/fixes_fips/0001_disable_http3.patch
