### PR TITLE
4900 update

### DIFF
--- a/prepare_source
+++ b/prepare_source
@@ -1,6 +1,6 @@
-version_orig="8.19.0-1"
+version_orig="8.21.0-2"
 version="$version_orig"
-version_suffix=gl1+bp1877
+version_suffix=gl0+bp1877
 
 git_src -b "debian/$version" "https://salsa.debian.org/debian/curl.git"
 


### PR DESCRIPTION
**What this PR does / why we need it**:

fixes CVEs [CVE-2026-5773](https://security-tracker.debian.org/tracker/CVE-2026-5773), [CVE-2026-6276](https://security-tracker.debian.org/tracker/CVE-2026-6276)


**Which issue(s) this PR fixes**:
Fixes gardenlinux/gardenlinux#4900
